### PR TITLE
Add golang to pre-commit

### DIFF
--- a/pre-commit/Dockerfile
+++ b/pre-commit/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-slim
 ENV PATH="$PATH:/root/.pyenv/bin:/root/.pyenv/shims"
 ENV version=2.9.3
 
-RUN apt update && apt install -y git bash curl build-essential libffi-dev libssl-dev libbz2-dev libncursesw5-dev libgdbm-dev liblzma-dev libsqlite3-dev tk-dev uuid-dev libreadline-dev nodejs npm zlib1g-dev && \
+RUN apt update && apt install -y git golang bash curl build-essential libffi-dev libssl-dev libbz2-dev libncursesw5-dev libgdbm-dev liblzma-dev libsqlite3-dev tk-dev uuid-dev libreadline-dev nodejs npm zlib1g-dev && \
     curl --location https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash && \
     pyenv update && \
     pyenv install 3.7.9 && \


### PR DESCRIPTION
According to https://pre-commit.com/#golang Go must be present to run go-based hooks.